### PR TITLE
Fix an issue where data wasn't getting retrieved properly from CRUD i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ For each resource that is supported, a basic CRUD interface is created.  So,
 for example for the RestApi resource you have these methods available in the
 client: 
 
-* list_restapis()
-* get_restapi(restapi_id=`a restapi id`)
-* create_restapi(name='foo', description='bar')
-* delete_restapi(restapi_id=`a restapi_id`)
+* list_rest_apis()
+* get_rest_api(restapi_id=`a restapi id`)
+* create_rest_api(name='foo', description='bar')
+* delete_rest_api(restapi_id=`a restapi_id`)
 
 For the create methods, the goal is to name the parameters the same as they are
 defined in the Amazon API Gateway API documentation.

--- a/petard/resource.py
+++ b/petard/resource.py
@@ -33,8 +33,7 @@ class Resource(object):
                     self.href = self._links['self']['href']
                 self.url = self._links.get('self', '/')
             elif key == '_embedded':
-                for item in response['_embedded']['item']:
-                    self.items.append(Resource(item))
+                self.items.append(Resource(response['_embedded']['item']))
             else:
                 setattr(self, key, response[key])
 

--- a/petard/resource.py
+++ b/petard/resource.py
@@ -33,7 +33,11 @@ class Resource(object):
                     self.href = self._links['self']['href']
                 self.url = self._links.get('self', '/')
             elif key == '_embedded':
-                self.items.append(Resource(response['_embedded']['item']))
+                if isinstance(response['_embedded']['item'], dict):
+                    self.items.append(Resource(response['_embedded']['item']))
+                else:
+                    for item in response['_embedded']['item']:
+                        self.items.append(Resource(item))
             else:
                 setattr(self, key, response[key])
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email='mitch@garnaat.com',
     url='https://github.com/garnaat/petard',
     packages=find_packages(exclude=['tests*']),
-    package_data={'petard': ['_version', 'data/apigateway/latest/*.json']},
+    package_data={'petard': ['_version', 'data/*.json', 'data/*/*.json']},
     install_requires=requires,
     license=open("LICENSE").read(),
     classifiers=(

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email='mitch@garnaat.com',
     url='https://github.com/garnaat/petard',
     packages=find_packages(exclude=['tests*']),
-    package_data={'petard': ['_version']},
+    package_data={'petard': ['_version', 'data/apigateway/latest/*.json']},
     install_requires=requires,
     license=open("LICENSE").read(),
     classifiers=(


### PR DESCRIPTION
…nterface.
First noticed an issue in getting the client:

```
>>>> import petard
>>>> c = petard.get_client(region_name='us-west-2')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/pypy-env/site-packages/petard-0.1.0-py2.7.egg/petard/__init__.py", line 53, in get_client
    return session.client('apigateway')
  File "/root/pypy-env/site-packages/boto3-1.1.2-py2.7.egg/boto3/session.py", line 199, in client
    aws_session_token=aws_session_token, config=config)
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/session.py", line 761, in create_client
    client_config=config, api_version=api_version)
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/client.py", line 53, in create_client
    service_model = self._load_service_model(service_name, api_version)
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/client.py", line 78, in _load_service_model
    api_version=api_version)
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/loaders.py", line 119, in _wrapper
    data = func(self, *args, **kwargs)
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/loaders.py", line 338, in load_service_model
    service_name, type_name)
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/loaders.py", line 119, in _wrapper
    data = func(self, *args, **kwargs)
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/loaders.py", line 280, in determine_latest_version
    return max(self.list_api_versions(service_name, type_name))
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/loaders.py", line 119, in _wrapper
    data = func(self, *args, **kwargs)
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/loaders.py", line 309, in list_api_versions
    raise DataNotFoundError(data_path=service_name)
DataNotFoundError: Unable to load data for: apigateway
```

So, the service-2.json file wasn't getting copied over properly, hence the change in setup.py to add it to package_data.

Next, I was attempting to list_api_keys() and was getting this error:

```
>>>> import petard
>>>> c = petard.get_client(region_name='us-west-2')
>>>> c.list_api_keys()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/client.py", line 270, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/client.py", line 331, in _make_api_call
    model=operation_model
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/hooks.py", line 226, in emit
    return self._emit(event_name, kwargs)
  File "/root/pypy-env/site-packages/botocore-1.1.12-py2.7.egg/botocore/hooks.py", line 209, in _emit
    response = handler(**kwargs)
  File "petard/__init__.py", line 37, in fix_response
    json.loads(parsed['json_body']))
  File "petard/resource.py", line 37, in __init__
    self.items.append(Resource(item))
  File "petard/resource.py", line 39, in __init__
    setattr(self, key, response[key])
TypeError: string index must be an integer, not unicode
```

Turns out if the key was _embedded, each of the keys themselves were being added as response objects instead of the whole dictionary. Hence the change in resource.py.

For reference, my response data looked like the following (with some values changed): 

```
{u'_embedded': {u'item': {u'name': u'my_first_key', u'enabled': False, u'stageKeys': u'abcd12345/test', u'_links': {u'apikey:delete': {u'href': u'/apikeys/apikey'}, u'self': {u'href': u'/apikeys/apikey'}, u'apikey:update': {u'href': u'/apikeys/apikey'}}, u'lastUpdatedDate': u'2015-09-22T18:38:51Z', u'createdDate': u'2015-09-22T18:38:28Z', u'id': u'apikey'}}, u'_links': {u'apikey:create': {u'href': u'/apikeys'}, u'curies': {u'href': u'http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-apikey-{rel}.html', u'name': u'apikey', u'templated': True}, u'self': {u'href': u'/apikeys'}, u'item': {u'href': u'/apikeys/apikey'}, u'apikey:by-key': {u'href': u'/apikeys/{api_Key}', u'templated': True}}}
```

Lastly, I updated the README for a couple tiny typos.

Let me know if I did anything wrong or if I'm using this completely incorrectly.
Thanks!
